### PR TITLE
Break hover tooltip content line at newline chars

### DIFF
--- a/addon/hover/text-hover.css
+++ b/addon/hover/text-hover.css
@@ -11,6 +11,7 @@
 	z-index: 100;
 	max-width: 600px;
 	opacity: 0;
+	white-space: pre-wrap;
 	transition: opacity .4s;
 	-moz-transition: opacity .4s;
 	-webkit-transition: opacity .4s;


### PR DESCRIPTION
Done to support newline characters in the Tern plugin "!doc"
definition.

Line wrapping by newline characters is also supported by the CodeMirror Tern plugin: https://github.com/codemirror/CodeMirror/blob/efca20989567651901895dae6532953386d191f1/addon/tern/tern.css#L62
